### PR TITLE
feat(login): 로그인 페이지 브랜드 다크 정렬 및 가독성 개선

### DIFF
--- a/src/component/page/LoginPage/LoginPage.tsx
+++ b/src/component/page/LoginPage/LoginPage.tsx
@@ -2,8 +2,8 @@ import styled from "styled-components";
 import CusInput from "../../../common/elements/textField/CusInput";
 import useLoginPage from "./useLoginPage";
 import CusButton from "../../../common/elements/buttons/CusButton";
-import {ChangeEvent} from "react";
-import {Alert} from "@chakra-ui/react";
+import { ChangeEvent } from "react";
+import { Alert } from "@chakra-ui/react";
 
 interface LoginPageProps {
 
@@ -12,7 +12,6 @@ interface LoginPageProps {
 function LoginPage(props: LoginPageProps) {
   const {
     userInfo,
-    userId,
     errMsg,
     handleChange,
     handleClickTitle,
@@ -20,84 +19,145 @@ function LoginPage(props: LoginPageProps) {
     handleClickSignUp,
     pressEnter,
   } = useLoginPage();
+
   return (
-    <StyledLoginPage>
-      {errMsg?.isShow && (
-        <Alert.Root status={errMsg.status as "error" | "warning" | "success" | "info"}>
-          <Alert.Indicator />
-          <Alert.Title>{errMsg.msg}</Alert.Title>
-        </Alert.Root>
-      )}
-      <span
-        className="title"
-        onClick={handleClickTitle}
-      >
-        Nadeliv
-      </span>
-      <div className="wrapper-body">
-        <CusInput
-          placeholder="ID"
-          value={userInfo.userId}
-          id="id"
-          name="id"
-          type="text"
-          onKeyUp={pressEnter}
-          onChange={(event:ChangeEvent<HTMLInputElement>) => handleChange(event, "id")}
-        />
-        <CusInput
-          placeholder="PASSWORD"
-          value={userInfo.userPassword}
-          type="password"
-          id="pw"
-          name="pw"
-          onKeyUp={pressEnter}
-          onChange={(event:ChangeEvent<HTMLInputElement>) => handleChange(event, "password")}
-        />
-      </div>
-      <div className="wrapper-footer">
-        <CusButton
-          onClick={handleClickSignUp}
-        >
-          SignUp
-        </CusButton>
-        <CusButton
-          onClick={handleClickLogin}
-        >
-          Login
-        </CusButton>
-      </div>
-    </StyledLoginPage>
+    <PageWrapper>
+      <Card>
+        {errMsg?.isShow && (
+          <Alert.Root status={errMsg.status as "error" | "warning" | "success" | "info"}>
+            <Alert.Indicator />
+            <Alert.Title>{errMsg.msg}</Alert.Title>
+          </Alert.Root>
+        )}
+
+        <Header>
+          <Title onClick={handleClickTitle}>nadeliv</Title>
+        </Header>
+
+        <Form>
+          <CusInput
+            placeholder="ID"
+            value={userInfo.userId}
+            id="id"
+            name="id"
+            type="text"
+            size="lg"
+            onKeyUp={pressEnter}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => handleChange(event, "id")}
+          />
+          <CusInput
+            placeholder="PASSWORD"
+            value={userInfo.userPassword}
+            type="password"
+            id="pw"
+            name="pw"
+            size="lg"
+            onKeyUp={pressEnter}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => handleChange(event, "password")}
+          />
+        </Form>
+
+        <Actions>
+          <CusButton
+            onClick={handleClickLogin}
+            size="lg"
+            w="full"
+            bg="rgba(255, 255, 255, 0.95)"
+            color="rgba(15, 15, 20, 0.95)"
+            fontWeight="600"
+            letterSpacing="0.02em"
+            _hover={{ bg: "rgba(255, 255, 255, 1)" }}
+            _active={{ bg: "rgba(235, 235, 240, 1)" }}
+          >
+            Login
+          </CusButton>
+          <CusButton
+            onClick={handleClickSignUp}
+            variant="outline"
+            size="lg"
+            w="full"
+            bg="transparent"
+            color="rgba(255, 255, 255, 0.9)"
+            borderColor="rgba(255, 255, 255, 0.2)"
+            fontWeight="500"
+            letterSpacing="0.02em"
+            _hover={{ bg: "rgba(255, 255, 255, 0.05)", borderColor: "rgba(255, 255, 255, 0.4)" }}
+            _active={{ bg: "rgba(255, 255, 255, 0.08)" }}
+          >
+            Sign Up
+          </CusButton>
+        </Actions>
+      </Card>
+    </PageWrapper>
   )
 };
 
 export default LoginPage;
 
-const StyledLoginPage = styled.div`
-  border: 1px solid gray;
-  padding: 2rem;
-  border-radius: 10px 10px;
-  width: 40vw;
-  max-width: 500px;
-  min-width: max-content;
-  //display: inline-block;
-  flex-direction: column;
-  gap: 1rem;
+const PageWrapper = styled.div`
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.05), transparent 55%),
+    radial-gradient(circle at 85% 80%, rgba(255, 255, 255, 0.03), transparent 55%);
+`;
+
+const Card = styled.div`
+  width: 100%;
+  max-width: 420px;
+  padding: 2.5rem 2rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
   display: flex;
   flex-direction: column;
-  .title {
-    font-weight: bold;
-    font-size: 4rem;
-    cursor: pointer;
-    width: fit-content;
-    white-space: nowrap;
+  gap: 1.5rem;
+
+  @media (prefers-color-scheme: light) {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: rgba(0, 0, 0, 0.08);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
   }
-  .wrapper-body {
-    display: flex;
-    flex-direction: column;
-    gap : 0.5rem;
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.25rem;
+`;
+
+const Title = styled.span`
+  font-family: Georgia, "Times New Roman", serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 3.5rem;
+  line-height: 1.1;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.95);
+  width: fit-content;
+
+  @media (prefers-color-scheme: light) {
+    color: rgba(15, 15, 20, 0.95);
   }
-  .wrapper-footer {
-    display: flex;
-    justify-content: space-between;
-  }
+`;
+
+const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 `;


### PR DESCRIPTION
- nadeliv 로고를 메인 페이지와 동일한 Georgia italic 스타일로 통일
- 다크 배경에서 묻히던 카드/입력창에 글래스모피즘 + 보더로 가독성 확보
- 버튼 위계 정리: Login 아이보리 솔리드 / Sign Up 아웃라인 고스트