### PR TITLE
feat: 검색엔진(구글·네이버) 등록을 위한 SEO 기본 설정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,13 +18,27 @@
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" sizes="any" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
+
+  <!-- SEO -->
   <meta
           name="description"
-          content="Nadeliv - Your Smart Travel Manager for Korea"
+          content="Nadeliv is a travel blog introducing Korea beyond Seoul — hidden destinations, local food, and travel guides for exploring every corner of Korea."
   />
+  <!-- 검색엔진 소유권 인증 (구글은 DNS TXT 레코드로 인증 완료) -->
+  <meta name="naver-site-verification" content="48c0b404dd7e1c082879918086e0fa7ea44343f7" />
+
+  <!-- Open Graph / 소셜 공유 -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Nadeliv" />
+  <meta property="og:title" content="Nadeliv — Discover Korea Beyond Seoul" />
+  <meta property="og:description" content="Hidden destinations, local food, and travel guides for exploring every corner of Korea." />
+  <meta property="og:url" content="https://www.nadeliv.com/" />
+  <meta property="og:image" content="https://www.nadeliv.com/logo512.png" />
+  <meta name="twitter:card" content="summary" />
+
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.svg" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <title>Nadeliv</title>
+  <title>Nadeliv — Discover Korea Beyond Seoul</title>
   <style>
     html, body {
       height: 100%;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,22 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Allow: /
+# 로그인/개인 영역은 크롤링 제외
+Disallow: /admin
+Disallow: /profile
+Disallow: /chat
+Disallow: /login
+Disallow: /user
+Disallow: /travel
+Disallow: /error
+Disallow: /blog/create
+Disallow: /blog/create-new
+Disallow: /blog/edit
+Disallow: /blog/my
+Disallow: /blog/draft
+Disallow: /blog/hidden
+Disallow: /blog/trash
+Disallow: /blog/bookmark
+Disallow: /blog/translations
+
+Sitemap: https://api.nadeliv.com/sitemap.xml

--- a/src/component/page/blog/ViewBlog/useViewBlog.ts
+++ b/src/component/page/blog/ViewBlog/useViewBlog.ts
@@ -12,6 +12,7 @@ import {useTranslatedPost} from "../../../../hooks/useI18nQueries";
 import {currentLocaleAtom, preferredLocaleAtom, resolveLocale} from "../../../../stores/jotai/localeAtom";
 import {LocaleCode, AvailableLocale, TranslatedBy, SUPPORTED_LOCALES} from "../../../../types/i18n/i18nTypes";
 import {useCurrentUser} from "../../../../hooks/useCurrentUser";
+import usePageMeta from "../../../../hooks/usePageMeta";
 
 export interface ViewBlogI18nState {
   currentLocale: LocaleCode;
@@ -121,6 +122,9 @@ function useViewBlog(props : ViewBlogProps) {
     }
     return document.contents;
   }, [translatedPost, document.contents]);
+
+  // SEO: 글별 브라우저 타이틀/설명 설정
+  usePageMeta(displayTitle, displayContent);
 
   // 글별 언어 전환 핸들러 (URL 경로로 반영)
   const handleLocaleChange = useCallback((locale: LocaleCode) => {

--- a/src/hooks/usePageMeta.ts
+++ b/src/hooks/usePageMeta.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+
+const DEFAULT_TITLE = "Nadeliv — Discover Korea Beyond Seoul";
+
+/**
+ * 페이지별 SEO 메타(브라우저 타이틀 + meta description) 설정 훅.
+ * CSR 환경에서 Googlebot 렌더링 시 페이지별 title/description 이 인덱싱되도록 한다.
+ * 언마운트 시 기본값으로 복원.
+ */
+export function usePageMeta(title?: string, description?: string) {
+  useEffect(() => {
+    if (title) {
+      window.document.title = `${title} | Nadeliv`;
+    }
+    return () => {
+      window.document.title = DEFAULT_TITLE;
+    };
+  }, [title]);
+
+  useEffect(() => {
+    if (!description) return;
+
+    const meta = window.document.querySelector<HTMLMetaElement>(
+      'meta[name="description"]'
+    );
+    if (!meta) return;
+
+    const original = meta.content;
+    // HTML 태그 제거 후 앞 160자만 사용
+    const plain = description.replace(/<[^>]*>/g, "").trim().slice(0, 160);
+    if (plain) {
+      meta.content = plain;
+    }
+    return () => {
+      meta.content = original;
+    };
+  }, [description]);
+}
+
+export default usePageMeta;


### PR DESCRIPTION
- index.html: 영문 title/description 개선, Open Graph·트위터 카드, 네이버 소유확인 메타태그 추가
- robots.txt: 비공개 라우트(admin/profile/chat/edit 등) 크롤링 차단, Sitemap 지시자 추가 (api.nadeliv.com/sitemap.xml)
- usePageMeta 훅 신설: 글별 브라우저 타이틀·meta description 동적 설정, ViewBlog 적용