### PR TITLE
chore(seo): 사이트맵 URL www 도메인으로 변경 + 네이버 소유확인 파일 추가

### DIFF
--- a/public/naverc7c3a807b206d058ddccf8abe706f473.html
+++ b/public/naverc7c3a807b206d058ddccf8abe706f473.html
@@ -1,0 +1,1 @@
+naver-site-verification: naverc7c3a807b206d058ddccf8abe706f473.html

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -19,4 +19,4 @@ Disallow: /blog/trash
 Disallow: /blog/bookmark
 Disallow: /blog/translations
 
-Sitemap: https://api.nadeliv.com/sitemap.xml
+Sitemap: https://www.nadeliv.com/sitemap.xml


### PR DESCRIPTION
- robots.txt: Sitemap 을 https://www.nadeliv.com/sitemap.xml 로 변경 (CloudFront /sitemap.xml behavior → 백엔드 라우팅 적용됨)
- 네이버 서치어드바이저 소유확인용 HTML 파일 추가 (S3 에는 이미 업로드됨)