### PR TITLE
fix(seo): 글 페이지 canonical·hreflang·html lang 동적 설정

### DIFF
--- a/src/component/page/blog/ViewBlog/useViewBlog.ts
+++ b/src/component/page/blog/ViewBlog/useViewBlog.ts
@@ -137,8 +137,36 @@ function useViewBlog(props : ViewBlogProps) {
     return document.contents;
   }, [translatedPost, document.contents]);
 
-  // SEO: 글별 브라우저 타이틀/설명 설정
-  usePageMeta(displayTitle, displayContent);
+  // SEO: 글별 브라우저 타이틀/설명 + canonical/hreflang/lang 설정
+  const originalLocale = (translatedPost?.originalLocale || document.originalLocale || 'ko') as LocaleCode;
+  const isTranslated = translatedPost?.isTranslated ?? false;
+
+  // 실제 표시 중인 언어: 번역이 있으면 activeLocale, 없으면 원본 fallback
+  const displayedLocale = isTranslated ? activeLocale : originalLocale;
+
+  const seoOptions = useMemo(() => {
+    if (!id) return undefined;
+    const origin = window.location.origin;
+    const urlOf = (locale: string) => `${origin}/blog/view/${locale}/${id}`;
+
+    // canonical: 번역 없이 원본을 fallback 표시 중이면 원본 URL 로 지정 (중복 색인 방지)
+    const canonicalUrl = urlOf(displayedLocale);
+
+    // hreflang: 원본 + 번역 완료된 언어만 (자기 자신 포함), x-default = 원본
+    const readyLocales = (translatedPost?.availableLocales ?? [])
+      .filter((l) => l.status === 'original' || l.status === 'completed' || l.status === 'manually_edited')
+      .map((l) => l.code);
+    const alternates = readyLocales.length > 0
+      ? [
+          ...readyLocales.map((code) => ({ hrefLang: code, href: urlOf(code) })),
+          { hrefLang: 'x-default', href: urlOf(originalLocale) },
+        ]
+      : undefined;
+
+    return { lang: displayedLocale, canonicalUrl, alternates };
+  }, [id, displayedLocale, originalLocale, translatedPost?.availableLocales]);
+
+  usePageMeta(displayTitle, displayContent, seoOptions);
 
   // 글별 언어 전환 핸들러 (URL 경로로 반영)
   const handleLocaleChange = useCallback((locale: LocaleCode) => {
@@ -154,8 +182,8 @@ function useViewBlog(props : ViewBlogProps) {
   // i18n 상태
   const i18nState: ViewBlogI18nState = useMemo(() => ({
     currentLocale: activeLocale,
-    originalLocale: (translatedPost?.originalLocale || document.originalLocale || 'ko') as LocaleCode,
-    isTranslated: translatedPost?.isTranslated ?? false,
+    originalLocale,
+    isTranslated,
     translatedBy: translatedPost?.translatedBy ?? null,
     availableLocales: translatedPost?.availableLocales ?? [],
     onLocaleChange: handleLocaleChange,

--- a/src/hooks/usePageMeta.ts
+++ b/src/hooks/usePageMeta.ts
@@ -1,13 +1,43 @@
 import { useEffect } from "react";
 
 const DEFAULT_TITLE = "Nadeliv — Discover Korea Beyond Seoul";
+const DEFAULT_LANG = "en";
+
+export interface PageMetaAlternate {
+  hrefLang: string; // "ko" | "en" | "zh" | "ja" | "x-default"
+  href: string;     // 절대 URL
+}
+
+export interface PageMetaOptions {
+  // 실제 표시 중인 콘텐츠 언어 → <html lang> 반영 (검색엔진 언어 판별 근거)
+  lang?: string;
+  // 이 페이지의 대표 URL (절대 URL). 번역이 없어 원본을 fallback 표시할 때는 원본 URL 지정
+  canonicalUrl?: string;
+  // 언어별 대체 버전 목록 (자기 자신 포함)
+  alternates?: PageMetaAlternate[];
+}
+
+// data-page-meta 마킹된 태그만 관리 (index.html 정적 태그와 충돌 방지)
+const MANAGED_ATTR = "data-page-meta";
+
+function removeManagedLinks(rel: string) {
+  window.document
+    .querySelectorAll(`link[rel="${rel}"][${MANAGED_ATTR}]`)
+    .forEach((el) => el.remove());
+}
 
 /**
- * 페이지별 SEO 메타(브라우저 타이틀 + meta description) 설정 훅.
- * CSR 환경에서 Googlebot 렌더링 시 페이지별 title/description 이 인덱싱되도록 한다.
+ * 페이지별 SEO 메타(브라우저 타이틀 + meta description + canonical/hreflang/lang) 설정 훅.
+ * CSR 환경에서 Googlebot 렌더링 시 페이지별 메타가 인덱싱되도록 한다.
  * 언마운트 시 기본값으로 복원.
  */
-export function usePageMeta(title?: string, description?: string) {
+export function usePageMeta(
+  title?: string,
+  description?: string,
+  options?: PageMetaOptions
+) {
+  const { lang, canonicalUrl, alternates } = options ?? {};
+
   useEffect(() => {
     if (title) {
       window.document.title = `${title} | Nadeliv`;
@@ -35,6 +65,52 @@ export function usePageMeta(title?: string, description?: string) {
       meta.content = original;
     };
   }, [description]);
+
+  // <html lang> — 표시 중인 콘텐츠의 실제 언어
+  useEffect(() => {
+    if (!lang) return;
+    window.document.documentElement.lang = lang;
+    return () => {
+      window.document.documentElement.lang = DEFAULT_LANG;
+    };
+  }, [lang]);
+
+  // canonical — 페이지 대표 URL (locale fallback 시 중복 색인 방지)
+  useEffect(() => {
+    if (!canonicalUrl) return;
+
+    removeManagedLinks("canonical");
+    const link = window.document.createElement("link");
+    link.rel = "canonical";
+    link.href = canonicalUrl;
+    link.setAttribute(MANAGED_ATTR, "true");
+    window.document.head.appendChild(link);
+
+    return () => {
+      removeManagedLinks("canonical");
+    };
+  }, [canonicalUrl]);
+
+  // hreflang alternates — 언어 버전 간 상호 참조 (검색 결과 언어 섞임 방지)
+  useEffect(() => {
+    if (!alternates || alternates.length === 0) return;
+
+    removeManagedLinks("alternate");
+    alternates.forEach(({ hrefLang, href }) => {
+      const link = window.document.createElement("link");
+      link.rel = "alternate";
+      link.hreflang = hrefLang;
+      link.href = href;
+      link.setAttribute(MANAGED_ATTR, "true");
+      window.document.head.appendChild(link);
+    });
+
+    return () => {
+      removeManagedLinks("alternate");
+    };
+    // alternates 배열은 매 렌더 새 참조가 될 수 있어 직렬화 키로 비교
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(alternates)]);
 }
 
 export default usePageMeta;


### PR DESCRIPTION
- usePageMeta: canonical/hreflang alternates/<html lang> 관리 옵션 추가 (data-page-meta 마킹으로 정적 태그와 충돌 방지, 언마운트 시 정리)
- useViewBlog: 번역 완료 언어만 alternates 구성(x-default=원본), 번역 없는 locale fallback 시 canonical 을 원본 URL 로 지정해 중복 색인 방지